### PR TITLE
Fix zenservice status check to handle both .status.progress and .status.Progress

### DIFF
--- a/velero/schedule/zen5-br-scripts-cm.yaml
+++ b/velero/schedule/zen5-br-scripts-cm.yaml
@@ -375,13 +375,13 @@ data:
         info "Waiting for zenservice $ZENSERVICE_NAME to complete in namespace $ZEN_NAMESPACE."
         zenservice_exists=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE --no-headers || echo fail)
         if [[ $zenservice_exists != "fail" ]]; then
-            completed=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE -o jsonpath='{.status.progress}')
+            completed=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE -o jsonpath='{.status.progress}{.status.Progress}')
             retry_count=60
             while [[ $completed != "100%" ]] && [[ $retry_count > 0 ]]
             do
                 info "Wait for zenservice $ZENSERVICE_NAME to complete. Completion % is $completed. Try again in 60s."
                 sleep 60
-                completed=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE -o jsonpath='{.status.progress}')
+                completed=$(oc get zenservice $ZENSERVICE_NAME -n $ZEN_NAMESPACE -o jsonpath='{.status.progress}{.status.Progress}')
                 retry_count=$((retry_count-1))
             done
 


### PR DESCRIPTION
# Summary

Update zenservice status check to handle both lowercase and uppercase Progress field variations in the JSONPath query.

# Files Changed

📄 `velero/schedule/zen5-br-scripts-cm.yaml`

Modified the zenservice completion status check to query both `.status.progress` and `.status.Progress` fields. This change ensures compatibility with different API versions or implementations that may use different casing for the Progress field. The JSONPath query now concatenates both fields, allowing the script to retrieve the completion percentage regardless of which field name is used by the zenservice resource. Since there should only ever be one field present at a time, we should not have a problem with overlapping results.

Related issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69384